### PR TITLE
Expose traversal path

### DIFF
--- a/test/runtime.spec.ts
+++ b/test/runtime.spec.ts
@@ -2,7 +2,7 @@ import * as jsc from 'jsverify';
 import * as _ from 'lodash';
 import * as assert from 'assert';
 import { promisify } from 'util';
-import { make, pmap, set } from '../src/runtime';
+import { make, pmap, set, map } from '../src/runtime';
 import { TestClass } from './test-class';
 
 const getWithTraversalPath = (dict: any, path: string[]): any => {
@@ -175,5 +175,22 @@ describe('set', () => {
     expect(newValue.b).toEqual('new value');
     expect(newValue.a).toEqual(['a']);
     expect(value.b).toEqual('original value');
+  });
+});
+
+describe('map', () => {
+  jsc.property('maps objects', jsc.dict(jsc.string), dict => {
+    const mapped = map(
+      dict,
+      (n: any): n is string => _.isString(n),
+      (n: string) => n.toUpperCase()
+    );
+    expect(mapped).toEqual(
+      Object.keys(dict).reduce((memo: any, n) => {
+        memo[n] = dict[n].toUpperCase();
+        return memo;
+      }, {})
+    );
+    return true;
   });
 });

--- a/test/runtime.spec.ts
+++ b/test/runtime.spec.ts
@@ -86,7 +86,7 @@ describe('pmap', () => {
     return true;
   });
 
-  jsc.property('exposes current traversalPath', jsc.json, async dict => {
+  jsc.property('exposes traversalPath', jsc.json, async dict => {
     const traversalPaths: string[][] = [];
     const mapped = await pmap(
       dict,
@@ -191,6 +191,24 @@ describe('map', () => {
         return memo;
       }, {})
     );
+    return true;
+  });
+
+  jsc.property('exposes traversalPath', jsc.json, dict => {
+    const traversalPaths: string[][] = [];
+    const mapped = map(
+      dict,
+      (n: any): n is string => _.isString(n),
+      (n: string, path: string[]) => {
+        traversalPaths.push(path);
+        return n.toUpperCase();
+      }
+    );
+
+    traversalPaths.forEach(path => {
+      const value = getWithTraversalPath(mapped, path);
+      expect(value).toEqual(value.toUpperCase());
+    });
     return true;
   });
 });


### PR DESCRIPTION
Expose the traveled path in `map` and `pmap` functions. This is handy if one would like to access the same location in another object.

Naive way to do this is:
```typescript
const getWithTraversalPath = (anotherObject: any, path: string[]): any => {
  return path.reduce((toBeTraversed: any, nextHop: string) => {
    return toBeTraversed[nextHop];
  }, anotherObject);
};
```