### PR TITLE
Add extra generic parameter to NamedTypeDefinition

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@smartlyio/oats-runtime",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "license": "MIT",
   "description": "Runtime for Oats a Openapi3 based generator for typescript aware servers and clients",
   "private": false,

--- a/src/reflection-type.ts
+++ b/src/reflection-type.ts
@@ -17,10 +17,10 @@ export type Type =
   | ObjectType
   | NamedType;
 
-export interface NamedTypeDefinition<A> {
+export interface NamedTypeDefinition<A, Shape = any> {
   readonly name: string;
   readonly definition: Type;
-  readonly maker: Maker<any, A>;
+  readonly maker: Maker<Shape, A>;
   readonly isA: null | ((value: any) => value is A);
 }
 


### PR DESCRIPTION
Because of the way it's setup, the Maker is always created with `any` as the shape, which makes using it a bit annoying as we don't get dev time type checking:

```ts
const typeTestTarget: oar.reflection.NamedTypeDefinition<TestTarget> = ({} as any);
typeTestTarget.maker({ literally: 'anything' }).success();
```