### PR TITLE
Fix shape type not being inferred properly in the set function

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@smartlyio/oats-runtime",
-  "version": "2.5.4",
+  "version": "2.5.5",
   "license": "MIT",
   "description": "Runtime for Oats a Openapi3 based generator for typescript aware servers and clients",
   "private": false,

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -45,9 +45,9 @@ export function text<Status extends number, Value>(
   };
 }
 
-export function set<Cls extends valueClass.ValueClass<Shape, any>, Shape>(
+export function set<Cls>(
   to: Cls,
-  set: Partial<Shape>
+  set: Cls extends valueClass.ValueClass<infer Shape, any> ? Partial<Shape> : never
 ): make.Make<Cls> {
   return (to as any).constructor.make({ ...to, ...set });
 }
@@ -137,7 +137,7 @@ function selectRecord<T extends { [key: string]: unknown }>(original: T, newReco
     return original;
   }
   if (original instanceof valueClass.ValueClass) {
-    return set(original, newRecord).success();
+    return set<valueClass.ValueClass<any, any>>(original, newRecord).success();
   }
   return newRecord;
 }


### PR DESCRIPTION
The previous changes to ValueClass kinda broke the types for `runtime.set` 😬

As it is the Shape type was inferred first, and then the Cls type was inferred from it. Unless the Shape being passed matches exactly the Shape in Cls, we'll get an error. This worked before because the Shape in ValueClass was just being ignored.
Now we're inferring the Shape from the Cls, so this works as predicted