### PR TITLE
Fix return type

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@smartlyio/oats-runtime",
-  "version": "2.6.0",
+  "version": "2.6.1",
   "license": "MIT",
   "description": "Runtime for Oats a Openapi3 based generator for typescript aware servers and clients",
   "private": false,

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -96,15 +96,15 @@ function mapInternal<A extends ValueType, T extends ValueType>(
 export function getAll<A extends ValueType, T extends ValueType>(
   value: A,
   predicate: (a: any) => a is T
-): readonly A[] {
+): readonly T[] {
   return getAllInternal(value, predicate);
 }
 
 function getAllInternal<A extends ValueType, T extends ValueType>(
   value: A,
   predicate: (a: any) => a is T
-): readonly A[] {
-  const match: A[] = [];
+): readonly T[] {
+  const match: T[] = [];
   if (predicate(value)) {
     match.push(value);
   }


### PR DESCRIPTION
`getAll` returns an array of items of the type that the predicate checks for, not of the type that is passed in as the value.