### PR TITLE
disallow __proto__ and constructor in object fields

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@smartlyio/oats-runtime",
-  "version": "2.6.2",
+  "version": "2.6.3",
   "license": "MIT",
   "description": "Runtime for Oats a Openapi3 based generator for typescript aware servers and clients",
   "private": false,

--- a/src/make.ts
+++ b/src/make.ts
@@ -309,6 +309,10 @@ export function makeAllOf(...all: any[]) {
   };
 }
 
+function isMagic(field: string) {
+  return ['__proto__', 'constructor'].indexOf(field) >= 0;
+}
+
 export function makeObject<
   P extends { [key: string]: Maker<any, any> | { optional: Maker<any, any> } }
 >(props: P, additionalProp?: any) {
@@ -318,6 +322,9 @@ export function makeObject<
     }
     const result: { [key: string]: any } = {};
     for (const index of Object.keys(props)) {
+      if (isMagic(index)) {
+        return error(`Using ${index} as field of an object is not allowed`);
+      }
       let maker: any = props[index];
       if (maker.optional) {
         if (!(index in value) || value[index] === undefined) {
@@ -332,6 +339,9 @@ export function makeObject<
       result[index] = propResult.success();
     }
     for (const index of Object.keys(value)) {
+      if (isMagic(index)) {
+        return error(`Using ${index} as objects additional field is not allowed.`);
+      }
       if (props[index]) {
         continue;
       }

--- a/test/make.spec.ts
+++ b/test/make.spec.ts
@@ -155,6 +155,36 @@ describe('makeArray', () => {
 });
 
 describe('makeObject', () => {
+  describe('magic fields', () => {
+    it('disallows __proto__', () => {
+      const obj = Object.create(null);
+      obj.__proto__ = make.makeNumber();
+      const fun = make.makeObject(obj);
+      const value = JSON.parse(`{"__proto__": 1}`);
+      expect(fun(value).errors[0].error).toEqual('Using __proto__ as field of an object is not allowed');
+    });
+
+    it('disallows constructor', () => {
+      const obj = Object.create(null);
+      obj.constructor = make.makeNumber();
+      const fun = make.makeObject(obj);
+      const value = JSON.parse(`{"constructor": 1}`);
+      expect(fun(value).errors[0].error).toEqual('Using constructor as field of an object is not allowed');
+    });
+
+    it('disallows __proto__ in additionalFields', () => {
+      const fun = make.makeObject({}, make.makeNumber());
+      const value = JSON.parse(`{"__proto__": 1}`);
+      expect(fun(value).errors[0].error).toEqual('Using __proto__ as objects additional field is not allowed.');
+    });
+
+    it('disallows constructor in additionalFields', () => {
+      const fun = make.makeObject({}, make.makeNumber());
+      const value = JSON.parse(`{"constructor": 1}`);
+      expect(fun(value).errors[0].error).toEqual('Using constructor as objects additional field is not allowed.');
+    });
+  });
+
   it('drops unknown properties if told to', () => {
     const fun = make.makeObject({ a: make.makeNumber() });
     expect(fun({ a: 1, missing: 'a' }, { unknownField: 'drop' }).success()).toEqual({ a: 1 });

--- a/test/make.spec.ts
+++ b/test/make.spec.ts
@@ -161,7 +161,9 @@ describe('makeObject', () => {
       obj.__proto__ = make.makeNumber();
       const fun = make.makeObject(obj);
       const value = JSON.parse(`{"__proto__": 1}`);
-      expect(fun(value).errors[0].error).toEqual('Using __proto__ as field of an object is not allowed');
+      expect(fun(value).errors[0].error).toEqual(
+        'Using __proto__ as field of an object is not allowed'
+      );
     });
 
     it('disallows constructor', () => {
@@ -169,19 +171,25 @@ describe('makeObject', () => {
       obj.constructor = make.makeNumber();
       const fun = make.makeObject(obj);
       const value = JSON.parse(`{"constructor": 1}`);
-      expect(fun(value).errors[0].error).toEqual('Using constructor as field of an object is not allowed');
+      expect(fun(value).errors[0].error).toEqual(
+        'Using constructor as field of an object is not allowed'
+      );
     });
 
     it('disallows __proto__ in additionalFields', () => {
       const fun = make.makeObject({}, make.makeNumber());
       const value = JSON.parse(`{"__proto__": 1}`);
-      expect(fun(value).errors[0].error).toEqual('Using __proto__ as objects additional field is not allowed.');
+      expect(fun(value).errors[0].error).toEqual(
+        'Using __proto__ as objects additional field is not allowed.'
+      );
     });
 
     it('disallows constructor in additionalFields', () => {
       const fun = make.makeObject({}, make.makeNumber());
       const value = JSON.parse(`{"constructor": 1}`);
-      expect(fun(value).errors[0].error).toEqual('Using constructor as objects additional field is not allowed.');
+      expect(fun(value).errors[0].error).toEqual(
+        'Using constructor as objects additional field is not allowed.'
+      );
     });
   });
 


### PR DESCRIPTION
`__proto__ `and `constructor` collide with the js prototypes. If we allow setting
those from user data we allow somebody to set the prototype of the constructed
object which might lead to really hard to figure out errors.

This becomes an issue when dealing with value classes where we actually need to
have the prototypes pointing to the value class instance and thus cannot just
do prototypeless objects with `Object.create(null)`

this is a bit of hack as there might well be valid uses of at least
`constructor` in some schema.  Better way would be to stop using classes and
change the isN checks to use some other way to distinguish objects like known
symbols or weakmaps. However as we rely in all places on instanceOf this is not
particularly easy. Or we could override instanceOf symbol to do this. All of
these would require more coding though so not sure if that is now warranted.

with Symbol.hasInstance something like 

```
const instanceTag = Symbol()
const Aclass = {
  [Symbol.hasInstance](instance) {
    return instance[instanceTag] === Aclass;
  }
}

const a = {
  [instanceTag]: Aclass
}

```

however then `{...a}` would pass on the instanceTag :/ if we make it non enumerable then _.clone and thus safe-navigation $sett wont keep the  instance which might be a bit annoying