### PR TITLE
fix: optional query params failing when no query params are provided

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -151,7 +151,7 @@ export function safe<
       op: ctx.op,
       headers: cleanHeaders(headers, ctx.headers),
       params: params(voidify(ctx.params)).success(throwRequestValidationError.bind(null, 'params')),
-      query: query(voidify(ctx.query)).success(throwRequestValidationError.bind(null, 'query')),
+      query: query(ctx.query).success(throwRequestValidationError.bind(null, 'query')),
       body: body(voidify(ctx.body)).success(throwRequestValidationError.bind(null, 'body')),
       requestContext: ctx.requestContext as any
     });


### PR DESCRIPTION
In openapi you can declare a query param that is optional like so:
```
- name: foo
  in: query
  required: false
  schema:
    type: boolean
```

However, now if you try to call the endpoint _without_ providing any query parameters you will get an error:
`"invalid request query : expected an object, but got \"null\" instead."`

This happens because we are tossing the empty query params object away in this `voidify` function. This commit removes the voidification of query parameters, which fixes the issue.

Not sure if this is a valid fix, as I don't know the story behind the voidification. Also note that this now allows `undefined` values through, which would've previously been converted to `null` by the voidification. This can be changed if needed.