### PR TITLE
flag missing body in client request

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@smartlyio/oats-runtime",
-  "version": "2.7.1",
+  "version": "2.7.2",
   "license": "MIT",
   "description": "Runtime for Oats a Openapi3 based generator for typescript aware servers and clients",
   "private": false,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@smartlyio/oats-runtime",
-  "version": "2.7.2",
+  "version": "2.7.3",
   "license": "MIT",
   "description": "Runtime for Oats a Openapi3 based generator for typescript aware servers and clients",
   "private": false,

--- a/src/client.ts
+++ b/src/client.ts
@@ -2,7 +2,7 @@ import * as server from './server';
 import * as assert from 'assert';
 import safe from '@smartlyio/safe-navigation';
 
-type HasOnlyOptionalTypes<O> = Partial<O> extends O ? true : false;
+type HasOnlyOptionalTypes<O> = Partial<O> extends O ? true : O extends void ? true : false;
 
 type MakeOptional<O, K extends string> = true extends HasOnlyOptionalTypes<O>
   ? { [P in K]?: O }

--- a/src/client.ts
+++ b/src/client.ts
@@ -2,19 +2,17 @@ import * as server from './server';
 import * as assert from 'assert';
 import safe from '@smartlyio/safe-navigation';
 
-type HeaderProp<H, Next> = H extends void ? Next : { headers: H } & Next;
-type QueryProp<Q, Next> = true extends HasOnlyOptionalTypes<Q>
-  ? { query?: Q } | ({ query?: Q } & Next) | Next
-  : { query: Q } | ({ query: Q } & Next);
-type BodyProp<B> = B extends void ? void : { body: B };
-
 type HasOnlyOptionalTypes<O> = Partial<O> extends O ? true : false;
+
+type MakeOptional<O, K extends string> = true extends HasOnlyOptionalTypes<O>
+  ? { [P in K]?: O }
+  : { [P in K]: O };
 
 export type ClientArg<
   H extends server.Headers | void,
   Q extends server.Query | void,
   B extends server.RequestBody<any> | void
-> = HeaderProp<H, QueryProp<Q, BodyProp<B>>>;
+> = MakeOptional<H, 'headers'> & MakeOptional<Q, 'query'> & MakeOptional<B, 'body'>;
 
 export type ClientEndpoint<
   H extends server.Headers | void,

--- a/test/client.spec.ts
+++ b/test/client.spec.ts
@@ -51,6 +51,12 @@ describe('ClientEndpoint', () => {
     void mock<client.ClientEndpoint<void, void, typeof body | void, typeof response>>()();
   });
 
+  it('allows body when body can be void', () => {
+    void mock<client.ClientEndpoint<void, void, typeof body | void, typeof response>>()({
+      body
+    });
+  });
+
   it('requires body with correct type', () => {
     void mock<client.ClientEndpoint<void, void, typeof body, typeof response>>()({
       // @ts-expect-error

--- a/test/client.spec.ts
+++ b/test/client.spec.ts
@@ -42,6 +42,18 @@ describe('ClientEndpoint', () => {
     });
   });
 
+  it('requires body', () => {
+    // @ts-expect-error
+    void mock<client.ClientEndpoint<void, void, typeof body, typeof response>>()();
+  });
+
+  it('requires body with correct type', () => {
+    void mock<client.ClientEndpoint<void, void, typeof body, typeof response>>()({
+      // @ts-expect-error
+      body: { foo: 1 }
+    });
+  });
+
   it('allows passing no query when body is present', () => {
     void mock<client.ClientEndpoint<void, { a?: string }, typeof body, typeof response>>()({
       body

--- a/test/client.spec.ts
+++ b/test/client.spec.ts
@@ -47,6 +47,10 @@ describe('ClientEndpoint', () => {
     void mock<client.ClientEndpoint<void, void, typeof body, typeof response>>()();
   });
 
+  it('allows no body when boy can be void', () => {
+    void mock<client.ClientEndpoint<void, void, typeof body | void, typeof response>>()();
+  });
+
   it('requires body with correct type', () => {
     void mock<client.ClientEndpoint<void, void, typeof body, typeof response>>()({
       // @ts-expect-error

--- a/test/client.spec.ts
+++ b/test/client.spec.ts
@@ -47,7 +47,7 @@ describe('ClientEndpoint', () => {
     void mock<client.ClientEndpoint<void, void, typeof body, typeof response>>()();
   });
 
-  it('allows no body when boy can be void', () => {
+  it('allows no body when body can be void', () => {
     void mock<client.ClientEndpoint<void, void, typeof body | void, typeof response>>()();
   });
 


### PR DESCRIPTION
turns out the "improvement" to allow not passing query parameters also lost the typecheck that a body needs to be there.