### PR TITLE
Ts magic shape of

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,3 +2,5 @@
 
 This package provides the runtime code required for using [@smartlyio/oats](https://www.npmjs.com/package/@smartlyio/oats) generated Openapi3 clients and servers. For usage examples see [oats github page](https://github.com/smartlyio/oats).
 
+
+

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@smartlyio/oats-runtime",
-  "version": "2.9.0",
+  "version": "2.9.0-beta.1",
   "license": "MIT",
   "description": "Runtime for Oats a Openapi3 based generator for typescript aware servers and clients",
   "private": false,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@smartlyio/oats-runtime",
-  "version": "2.9.0-beta.1",
+  "version": "2.9.0",
   "license": "MIT",
   "description": "Runtime for Oats a Openapi3 based generator for typescript aware servers and clients",
   "private": false,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@smartlyio/oats-runtime",
-  "version": "2.8.0",
+  "version": "2.8.1",
   "license": "MIT",
   "description": "Runtime for Oats a Openapi3 based generator for typescript aware servers and clients",
   "private": false,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@smartlyio/oats-runtime",
-  "version": "2.8.1",
+  "version": "2.9.0",
   "license": "MIT",
   "description": "Runtime for Oats a Openapi3 based generator for typescript aware servers and clients",
   "private": false,

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -8,15 +8,25 @@ export { make, server, client, valueClass, reflection };
 
 export const noContentContentType = 'oatsNoContent' as const;
 
-export type ShapeOf<A> = A extends string
-  ? string
-  : A extends number
-  ? number
-  : A extends boolean
-  ? boolean
+type Scalar = number | string | boolean;
+
+const typeWitnessKey = Symbol();
+const tagKey = Symbol();
+
+type ScalarWithoutBrand<V> = V extends { [typeWitnessKey]: infer S } ? S : V;
+
+export type ShapeOf<A> = A extends Scalar
+  ? ScalarWithoutBrand<A>
+  : unknown extends A
+  ? unknown
   : A extends Array<infer Item>
   ? Array<ShapeOf<Item>>
   : { [K in keyof A]: ShapeOf<A[K]> };
+
+export type BrandedScalar<Type, Tag> = Type & {
+  [typeWitnessKey]: Type;
+  [tagKey]: Tag;
+};
 
 export function setHeaders<
   Status extends number,

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -8,6 +8,16 @@ export { make, server, client, valueClass, reflection };
 
 export const noContentContentType = 'oatsNoContent' as const;
 
+export type ShapeOf<A> = A extends string
+  ? string
+  : A extends number
+  ? number
+  : A extends boolean
+  ? boolean
+  : A extends Array<infer Item>
+  ? Array<ShapeOf<Item>>
+  : { [K in keyof A]: ShapeOf<A[K]> };
+
 export function setHeaders<
   Status extends number,
   ConntentType,
@@ -54,7 +64,7 @@ export function text<Status extends number, Value>(
 
 export function set<Cls>(
   to: Cls,
-  set: Cls extends valueClass.ValueClass<infer Shape, any> ? Partial<Shape> : never
+  set: Cls extends valueClass.ValueClass<any, any> ? Partial<ShapeOf<Cls>> : never
 ): make.Make<Cls> {
   return (to as any).constructor.make({ ...to, ...set });
 }

--- a/src/value-class.ts
+++ b/src/value-class.ts
@@ -1,4 +1,5 @@
 import { NamedTypeDefinition } from './reflection-type';
+import { ShapeOf } from './runtime';
 
 export type Branded<A, BrandTag> = A & Brand<BrandTag>;
 
@@ -38,7 +39,7 @@ export type Writable<T> = T extends ReadonlyArray<infer R>
 
 export function toJSON<Cls>(
   value: Cls
-): Cls extends ValueClass<infer Shape, any> ? Writable<Shape> : never {
+): Cls extends ValueClass<any, any> ? Writable<ShapeOf<Cls>> : never {
   // we cant use _.cloneDeep as that copies the instance allowing a surprising way to
   // create proof carrying objects that do not respect the class constraints
   return asPlainObject(value as any); // how to say that 'this' is the extending class

--- a/test/shape-of.spec.ts
+++ b/test/shape-of.spec.ts
@@ -47,6 +47,20 @@ describe('ShapeOf', () => {
     assignableTo<runtime.ShapeOf<Value[]>>({});
   });
 
+  it('Shapes ReadonlyArrays', () => {
+    assignableTo<runtime.ShapeOf<readonly string[]>>(['a']);
+    // @ts-expect-error
+    assignableTo<runtime.ShapeOf<readonly string[]>>([1]);
+    // @ts-expect-error
+    assignableTo<runtime.ShapeOf<readonly string[]>>({});
+
+    assignableTo<readonly string[]>([] as runtime.ShapeOf<readonly string[]>);
+    assignableTo<readonly string[]>([] as runtime.ShapeOf<string[]>);
+    // @ts-expect-error
+    assignableTo<string[]>([] as runtime.ShapeOf<readonly string[]>);
+    assignableTo<string[]>([] as runtime.ShapeOf<string[]>);
+  });
+
   it('Shapes Objects', () => {
     assignableTo<runtime.ShapeOf<{ a: Value }>>({ a: 'a' });
     // @ts-expect-error

--- a/test/shape-of.spec.ts
+++ b/test/shape-of.spec.ts
@@ -9,6 +9,13 @@ const tagNum = Symbol();
 type ValueNum = runtime.BrandedScalar<number, typeof tagNum>;
 const tagBool = Symbol();
 type ValueBool = runtime.BrandedScalar<boolean, typeof tagBool>;
+const tagNull = Symbol();
+type ValueNull = runtime.BrandedScalar<null, typeof tagNull>;
+const tagUndefined = Symbol();
+type ValueUndefined = runtime.BrandedScalar<undefined, typeof tagUndefined>;
+
+const tagNullOrString = Symbol();
+type ValueNullOrString = runtime.BrandedScalar<null | string, typeof tagNullOrString>;
 
 function assignableTo<T>(_t: T) {
   return;
@@ -24,6 +31,9 @@ class BrandedClass2 extends runtime.valueClass.ValueClass<never, EnumTag2> {
   a = 'a';
 }
 
+type CustomShaped = runtime.Shaped<{ f: number }, string>;
+type CustomIndexType = runtime.Shaped<{ [k: string]: number }, string>;
+
 describe('ShapeOf', () => {
   it('works with branded types', () => {
     assignableTo<runtime.ShapeOf<Value>>('a');
@@ -37,6 +47,19 @@ describe('ShapeOf', () => {
     assignableTo<runtime.ShapeOf<ValueBool>>(true);
     // @ts-expect-error
     assignableTo<runtime.ShapeOf<ValueBool>>(1);
+
+    assignableTo<runtime.ShapeOf<ValueNull>>(null);
+    // @ts-expect-error
+    assignableTo<runtime.ShapeOf<ValueNull>>(1);
+
+    assignableTo<runtime.ShapeOf<ValueUndefined>>(undefined);
+    // @ts-expect-error
+    assignableTo<runtime.ShapeOf<ValueUndefined>>(null);
+
+    assignableTo<runtime.ShapeOf<ValueNullOrString>>(null);
+    assignableTo<runtime.ShapeOf<ValueNullOrString>>('aa');
+    // @ts-expect-error prevent assign to wrong value
+    assignableTo<runtime.ShapeOf<ValueNullOrString>>(1);
   });
 
   it('Shapes Arrays', () => {
@@ -88,34 +111,58 @@ describe('ShapeOf', () => {
     // @ts-expect-error
     assignableTo<runtime.ShapeOf<string | number>>(true);
   });
+
+  describe('Shaped', () => {
+    it('can retrieve the shape', () => {
+      assignableTo<runtime.ShapeOf<CustomShaped>>('abc');
+
+      assignableTo<runtime.ShapeOf<CustomIndexType>>('abc');
+      // @ts-expect-error shape of index type does not allow invalid field types
+      assignableTo<runtime.ShapeOf<CustomIndexType>>({ p: 1 });
+    });
+
+    it('does not get confused by index types', () => {
+      assignableTo<runtime.ShapeOf<{ [k: string]: number }>>({ k: 1 });
+      // @ts-expect-error index type does not accidentally extend shape tag
+      assignableTo<runtime.ShapeOf<{ [k: string]: number }>>(1);
+    });
+
+    it('does not leak the shape tags to destructuring', () => {
+      const a: CustomShaped = { f: 1 } as any;
+      const { ...r } = a;
+      assignableTo<runtime.ShapeOf<typeof r>>({ f: 1 });
+      // @ts-expect-error shape gets leaked :shrug:
+      assignableTo<runtime.ShapeOf<typeof r>>('abc');
+    });
+  });
 });
 
 describe('Branding', () => {
   it('separates classes', () => {
     const a: BrandedClass = {} as any;
-    // @ts-expect-error
-    assignableTo<BrandedClass2>(a); // prevents cross assign
+    // @ts-expect-error cross assign is prevented
+    assignableTo<BrandedClass2>(a);
     assignableTo<BrandedClass>(a); // allaws assign with correct branding
 
     const { ...r } = a;
-    // @ts-expect-error
-    assignableTo<BrandedClass>(r); // destructuring loses branding
+    // @ts-expect-error destructuring loses branding
+    assignableTo<BrandedClass>(r);
   });
   it('separates types', () => {
-    // @ts-expect-error
-    assignableTo<Value>('a'); // prevent unbranded assign
+    // @ts-expect-error prevent unbranded assign
+    assignableTo<Value>('a');
     assignableTo<Value>('a' as Value); // allow assign with branded value
-    // @ts-expect-error
-    assignableTo<Value>('a' as Value2); // prevent cross assign
+    // @ts-expect-error prevent cross assign
+    assignableTo<Value>('a' as Value2);
     assignableTo<Value2>('a' as Value2);
 
-    // @ts-expect-error
-    assignableTo<Value>(1); // prevent assign with wrong scalar type
-    // @ts-expect-error
-    assignableTo<Value>(1 as Value); // prevent 'as' with incompatible type
+    // @ts-expect-error prevent assign with wrong scalar type
+    assignableTo<Value>(1);
+    // @ts-expect-error prevent 'as' with incompatible type
+    assignableTo<Value>(1 as Value);
 
-    // @ts-expect-error
-    const { ...r } = 'a' as Value; // cannot destructure branded scalars
+    // @ts-expect-error cannot destructure branded scalars
+    const { ...r } = 'a' as Value;
     r === r;
   });
 });

--- a/test/shape-of.spec.ts
+++ b/test/shape-of.spec.ts
@@ -1,0 +1,107 @@
+import * as runtime from '../src/runtime';
+
+const tag = Symbol();
+type Value = runtime.BrandedScalar<string, typeof tag>;
+const tag2 = Symbol();
+type Value2 = runtime.BrandedScalar<string, typeof tag2>;
+
+const tagNum = Symbol();
+type ValueNum = runtime.BrandedScalar<number, typeof tagNum>;
+const tagBool = Symbol();
+type ValueBool = runtime.BrandedScalar<boolean, typeof tagBool>;
+
+function assignableTo<T>(_t: T) {
+  return;
+}
+
+enum EnumTag {}
+class BrandedClass extends runtime.valueClass.ValueClass<never, EnumTag> {
+  a = 'a';
+}
+
+enum EnumTag2 {}
+class BrandedClass2 extends runtime.valueClass.ValueClass<never, EnumTag2> {
+  a = 'a';
+}
+
+describe('ShapeOf', () => {
+  it('works with branded types', () => {
+    assignableTo<runtime.ShapeOf<Value>>('a');
+    // @ts-expect-error
+    assignableTo<runtime.ShapeOf<Value>>(1);
+
+    assignableTo<runtime.ShapeOf<ValueNum>>(1);
+    // @ts-expect-error
+    assignableTo<runtime.ShapeOf<ValueNum>>('a');
+
+    assignableTo<runtime.ShapeOf<ValueBool>>(true);
+    // @ts-expect-error
+    assignableTo<runtime.ShapeOf<ValueBool>>(1);
+  });
+
+  it('Shapes Arrays', () => {
+    assignableTo<runtime.ShapeOf<Value[]>>(['a']);
+    // @ts-expect-error
+    assignableTo<runtime.ShapeOf<Value[]>>([1]);
+    // @ts-expect-error
+    assignableTo<runtime.ShapeOf<Value[]>>({});
+  });
+
+  it('Shapes Objects', () => {
+    assignableTo<runtime.ShapeOf<{ a: Value }>>({ a: 'a' });
+    // @ts-expect-error
+    assignableTo<runtime.ShapeOf<{ a: Value }>>({ a: 1 }); // prevent nested type mismatch
+    // @ts-expect-error
+    assignableTo<runtime.ShapeOf<{ a: Value }>>({ b: 'a' }); // prevent unknown fields
+
+    assignableTo<runtime.ShapeOf<BrandedClass>>({ a: 'a' });
+    // @ts-expect-error
+    assignableTo<runtime.ShapeOf<BrandedClass>>({ b: 'a' });
+
+    assignableTo<runtime.ShapeOf<BrandedClass>>({ a: 'a' } as BrandedClass2);
+    assignableTo<runtime.ShapeOf<BrandedClass2>>({ a: 'a' } as BrandedClass);
+  });
+
+  it('keeps type literal', () => {
+    assignableTo<runtime.ShapeOf<'abc'>>('abc');
+    // @ts-expect-error
+    assignableTo<runtime.ShapeOf<'abc'>>('zzz');
+  });
+
+  it('follows unions', () => {
+    assignableTo<runtime.ShapeOf<string | number>>(1);
+    assignableTo<runtime.ShapeOf<string | number>>('a');
+    // @ts-expect-error
+    assignableTo<runtime.ShapeOf<string | number>>(true);
+  });
+});
+
+describe('Branding', () => {
+  it('separates classes', () => {
+    const a: BrandedClass = {} as any;
+    // @ts-expect-error
+    assignableTo<BrandedClass2>(a); // prevents cross assign
+    assignableTo<BrandedClass>(a); // allaws assign with correct branding
+
+    const { ...r } = a;
+    // @ts-expect-error
+    assignableTo<BrandedClass>(r); // destructuring loses branding
+  });
+  it('separates types', () => {
+    // @ts-expect-error
+    assignableTo<Value>('a'); // prevent unbranded assign
+    assignableTo<Value>('a' as Value); // allow assign with branded value
+    // @ts-expect-error
+    assignableTo<Value>('a' as Value2); // prevent cross assign
+    assignableTo<Value2>('a' as Value2);
+
+    // @ts-expect-error
+    assignableTo<Value>(1); // prevent assign with wrong scalar type
+    // @ts-expect-error
+    assignableTo<Value>(1 as Value); // prevent 'as' with incompatible type
+
+    // @ts-expect-error
+    const { ...r } = 'a' as Value; // cannot destructure branded scalars
+    r === r;
+  });
+});

--- a/test/test-class.ts
+++ b/test/test-class.ts
@@ -1,12 +1,11 @@
 import { ValueClass } from '../src/value-class';
 import { createMakerWith, Make, makeArray, makeObject, Maker, makeString } from '../src/make';
+import { ShapeOf } from '../src/runtime';
 
-export interface ShapeOfTestClass {
-  a: ReadonlyArray<string>;
-  b: string;
-}
-export class TestClass extends ValueClass<ShapeOfTestClass, 1> {
-  static make(v: ShapeOfTestClass): Make<TestClass> {
+export type ShapeOfTestClass = ShapeOf<TestClass>;
+
+export class TestClass extends ValueClass<never, 1> {
+  static make(v: ShapeOf<TestClass>): Make<TestClass> {
     return makeTestClass(v);
   }
   public b!: string;
@@ -20,4 +19,4 @@ export class TestClass extends ValueClass<ShapeOfTestClass, 1> {
     Object.assign(this, value);
   }
 }
-export const makeTestClass: Maker<ShapeOfTestClass, TestClass> = createMakerWith(TestClass);
+export const makeTestClass: Maker<ShapeOf<TestClass>, TestClass> = createMakerWith(TestClass);


### PR DESCRIPTION
use type level function to produce the ShapeOf instead of constructing those in code gen

 - [x] provide way to provide shapes for manually defined types (ie types coming through some `resolve` hack)
 
 required for https://github.com/smartlyio/oats/pull/169