### PR TITLE
Allow name in file object

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@smartlyio/oats-runtime",
-  "version": "2.9.0",
+  "version": "2.10.0",
   "license": "MIT",
   "description": "Runtime for Oats a Openapi3 based generator for typescript aware servers and clients",
   "private": false,

--- a/src/make.ts
+++ b/src/make.ts
@@ -381,7 +381,11 @@ export class File {
   // @ts-ignore
   private brand: FileBrand;
 
-  constructor(public readonly path: string, public readonly size: number) {}
+  constructor(
+    public readonly path: string,
+    public readonly size: number,
+    public readonly name?: string
+  ) {}
 }
 
 function checkBinary(value: any) {


### PR DESCRIPTION
Currently oats strips the file object from many fields including the name. Add name field to the file object.