### PR TITLE
Add a toShape helper function so people stop casting to classes to ShapeOf

### DIFF
--- a/src/value-class.ts
+++ b/src/value-class.ts
@@ -40,6 +40,10 @@ export type Writable<T> = T extends ReadonlyArray<infer R>
 export function toJSON<Cls>(
   value: Cls
 ): Cls extends ValueClass<any, any> ? Writable<ShapeOf<Cls>> : never {
+  return toShape(value) as any;
+}
+
+export function toShape<Cls>(value: Cls): Cls extends ValueClass<any, any> ? ShapeOf<Cls> : never {
   // we cant use _.cloneDeep as that copies the instance allowing a surprising way to
   // create proof carrying objects that do not respect the class constraints
   return asPlainObject(value as any); // how to say that 'this' is the extending class

--- a/test/value-class.spec.ts
+++ b/test/value-class.spec.ts
@@ -1,4 +1,4 @@
-import { toJSON } from '../src/value-class';
+import { toJSON, toShape } from '../src/value-class';
 import { TestClass } from './test-class';
 
 describe('ValueClass', () => {
@@ -6,6 +6,15 @@ describe('ValueClass', () => {
     it('returns a plain javascript object', () => {
       const value = TestClass.make({ b: 'a', a: ['a'] }).success();
       const json = toJSON(value);
+      expect(json instanceof TestClass).toBeFalsy();
+      expect(json.a).toEqual(['a']);
+      expect(json.b).toEqual('a');
+    });
+  });
+  describe('toShape', () => {
+    it('returns a plain javascript object', () => {
+      const value = TestClass.make({ b: 'a', a: ['a'] }).success();
+      const json = toShape(value);
       expect(json instanceof TestClass).toBeFalsy();
       expect(json.a).toEqual(['a']);
       expect(json.b).toEqual('a');


### PR DESCRIPTION
`toJson` returns a writable version