### PR TITLE
ShapeOf is no longer necessary

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@smartlyio/oats-runtime",
-  "version": "2.12.1",
+  "version": "2.13.0",
   "license": "MIT",
   "description": "Runtime for Oats a Openapi3 based generator for typescript aware servers and clients",
   "private": false,
@@ -38,7 +38,7 @@
     "client"
   ],
   "devDependencies": {
-    "@smartlyio/oats": "2.15.0",
+    "@smartlyio/oats": "2.15.1",
     "@smartlyio/oats-fast-check": "0.1.1",
     "@types/jest": "26.0.22",
     "@types/lodash": "4.14.168",

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -87,13 +87,13 @@ export function text<Status extends number, Value>(
 
 export function set<Cls>(
   to: Cls,
-  set: Cls extends valueClass.ValueClass<any> ? Partial<ShapeOf<Cls>> : never
+  set: Cls extends valueClass.ValueClass ? Partial<ShapeOf<Cls>> : never
 ): make.Make<Cls> {
   return (to as any).constructor.make({ ...to, ...set });
 }
 
 type ValueType =
-  | valueClass.ValueClass<any>
+  | valueClass.ValueClass
   | { [key: string]: any }
   | readonly any[]
   | string
@@ -207,7 +207,7 @@ function selectRecord<T extends { [key: string]: unknown }>(original: T, newReco
     return original;
   }
   if (original instanceof valueClass.ValueClass) {
-    return set<valueClass.ValueClass<any>>(original, newRecord).success();
+    return set<valueClass.ValueClass>(original, newRecord).success() as T;
   }
   return newRecord;
 }

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -87,13 +87,13 @@ export function text<Status extends number, Value>(
 
 export function set<Cls>(
   to: Cls,
-  set: Cls extends valueClass.ValueClass<any, any> ? Partial<ShapeOf<Cls>> : never
+  set: Cls extends valueClass.ValueClass<any> ? Partial<ShapeOf<Cls>> : never
 ): make.Make<Cls> {
   return (to as any).constructor.make({ ...to, ...set });
 }
 
 type ValueType =
-  | valueClass.ValueClass<any, any>
+  | valueClass.ValueClass<any>
   | { [key: string]: any }
   | readonly any[]
   | string
@@ -207,7 +207,7 @@ function selectRecord<T extends { [key: string]: unknown }>(original: T, newReco
     return original;
   }
   if (original instanceof valueClass.ValueClass) {
-    return set<valueClass.ValueClass<any, any>>(original, newRecord).success();
+    return set<valueClass.ValueClass<any>>(original, newRecord).success();
   }
   return newRecord;
 }

--- a/src/value-class.ts
+++ b/src/value-class.ts
@@ -1,12 +1,6 @@
 import { NamedTypeDefinition } from './reflection-type';
 import { ShapeOf } from './runtime';
 
-export type Branded<A, BrandTag> = A & Brand<BrandTag>;
-
-export class Brand<B> {
-  protected readonly valueClassBrand!: B; // branding, DO NOT ACCESS
-}
-
 function asPlainObject(value: any): any {
   if (Array.isArray(value)) {
     return value.map(asPlainObject) as any;
@@ -20,8 +14,8 @@ function asPlainObject(value: any): any {
   return value;
 }
 
-export class ValueClass<BrandTag> extends Brand<BrandTag> {
-  public static reflection: NamedTypeDefinition<ValueClass<any>>;
+export class ValueClass {
+  public static reflection: NamedTypeDefinition<ValueClass>;
 }
 
 type WritableArray<T> = Array<Writable<T>>;
@@ -36,13 +30,11 @@ export type Writable<T> = T extends ReadonlyArray<infer R>
   ? WritableObject<T>
   : T;
 
-export function toJSON<Cls>(
-  value: Cls
-): Cls extends ValueClass<any> ? Writable<ShapeOf<Cls>> : never {
+export function toJSON<Cls>(value: Cls): Cls extends ValueClass ? Writable<ShapeOf<Cls>> : never {
   return toShape(value) as any;
 }
 
-export function toShape<Cls>(value: Cls): Cls extends ValueClass<any> ? ShapeOf<Cls> : never {
+export function toShape<Cls>(value: Cls): Cls extends ValueClass ? ShapeOf<Cls> : never {
   // we cant use _.cloneDeep as that copies the instance allowing a surprising way to
   // create proof carrying objects that do not respect the class constraints
   return asPlainObject(value as any); // how to say that 'this' is the extending class

--- a/src/value-class.ts
+++ b/src/value-class.ts
@@ -20,9 +20,8 @@ function asPlainObject(value: any): any {
   return value;
 }
 
-export class ValueClass<Shape, BrandTag> extends Brand<BrandTag> {
-  public static reflection: NamedTypeDefinition<ValueClass<any, any>>;
-  protected readonly valueClassShape!: Shape; // stops TypeScript from ignoring the "Shape" type, DO NOT ACCESS
+export class ValueClass<BrandTag> extends Brand<BrandTag> {
+  public static reflection: NamedTypeDefinition<ValueClass<any>>;
 }
 
 type WritableArray<T> = Array<Writable<T>>;
@@ -39,11 +38,11 @@ export type Writable<T> = T extends ReadonlyArray<infer R>
 
 export function toJSON<Cls>(
   value: Cls
-): Cls extends ValueClass<any, any> ? Writable<ShapeOf<Cls>> : never {
+): Cls extends ValueClass<any> ? Writable<ShapeOf<Cls>> : never {
   return toShape(value) as any;
 }
 
-export function toShape<Cls>(value: Cls): Cls extends ValueClass<any, any> ? ShapeOf<Cls> : never {
+export function toShape<Cls>(value: Cls): Cls extends ValueClass<any> ? ShapeOf<Cls> : never {
   // we cant use _.cloneDeep as that copies the instance allowing a surprising way to
   // create proof carrying objects that do not respect the class constraints
   return asPlainObject(value as any); // how to say that 'this' is the extending class

--- a/test/reflection-type.spec.ts
+++ b/test/reflection-type.spec.ts
@@ -11,7 +11,7 @@ type Maker<A, R> = runtime.make.Maker<A, R>;
 
 describe('reflection-type', () => {
   describe('Traversal', () => {
-    class ArrayTestClass extends ValueClass<TestClass, 1> {
+    class ArrayTestClass extends ValueClass<1> {
       static make(v: any): Make<ArrayTestClass> {
         return makeArrayTestClass(v);
       }
@@ -31,7 +31,7 @@ describe('reflection-type', () => {
       ArrayTestClass
     );
 
-    class TestClass extends ValueClass<TestClass, 1> {
+    class TestClass extends ValueClass<1> {
       static make(v: any): Make<TestClass> {
         return makeTestClass(v);
       }

--- a/test/reflection-type.spec.ts
+++ b/test/reflection-type.spec.ts
@@ -11,7 +11,7 @@ type Maker<A, R> = runtime.make.Maker<A, R>;
 
 describe('reflection-type', () => {
   describe('Traversal', () => {
-    class ArrayTestClass extends ValueClass<1> {
+    class ArrayTestClass extends ValueClass {
       static make(v: any): Make<ArrayTestClass> {
         return makeArrayTestClass(v);
       }
@@ -31,7 +31,7 @@ describe('reflection-type', () => {
       ArrayTestClass
     );
 
-    class TestClass extends ValueClass<1> {
+    class TestClass extends ValueClass {
       static make(v: any): Make<TestClass> {
         return makeTestClass(v);
       }

--- a/test/shape-of.spec.ts
+++ b/test/shape-of.spec.ts
@@ -21,13 +21,13 @@ function assignableTo<T>(_t: T) {
   return;
 }
 
-enum EnumTag {}
-class BrandedClass extends runtime.valueClass.ValueClass<EnumTag> {
+class BrandedClass extends runtime.valueClass.ValueClass {
+  #brand = null;
   a = 'a';
 }
 
-enum EnumTag2 {}
-class BrandedClass2 extends runtime.valueClass.ValueClass<EnumTag2> {
+class BrandedClass2 extends runtime.valueClass.ValueClass {
+  #brand = null;
   a = 'a';
 }
 

--- a/test/shape-of.spec.ts
+++ b/test/shape-of.spec.ts
@@ -22,12 +22,12 @@ function assignableTo<T>(_t: T) {
 }
 
 class BrandedClass extends runtime.valueClass.ValueClass {
-  #brand = null;
+  private readonly brand = null;
   a = 'a';
 }
 
 class BrandedClass2 extends runtime.valueClass.ValueClass {
-  #brand = null;
+  private readonly brand = null;
   a = 'a';
 }
 

--- a/test/shape-of.spec.ts
+++ b/test/shape-of.spec.ts
@@ -22,12 +22,12 @@ function assignableTo<T>(_t: T) {
 }
 
 enum EnumTag {}
-class BrandedClass extends runtime.valueClass.ValueClass<never, EnumTag> {
+class BrandedClass extends runtime.valueClass.ValueClass<EnumTag> {
   a = 'a';
 }
 
 enum EnumTag2 {}
-class BrandedClass2 extends runtime.valueClass.ValueClass<never, EnumTag2> {
+class BrandedClass2 extends runtime.valueClass.ValueClass<EnumTag2> {
   a = 'a';
 }
 

--- a/test/test-class.ts
+++ b/test/test-class.ts
@@ -4,7 +4,7 @@ import { ShapeOf } from '../src/runtime';
 
 export type ShapeOfTestClass = ShapeOf<TestClass>;
 
-export class TestClass extends ValueClass<never, 1> {
+export class TestClass extends ValueClass<1> {
   static make(v: ShapeOf<TestClass>): Make<TestClass> {
     return makeTestClass(v);
   }

--- a/test/test-class.ts
+++ b/test/test-class.ts
@@ -4,7 +4,7 @@ import { ShapeOf } from '../src/runtime';
 
 export type ShapeOfTestClass = ShapeOf<TestClass>;
 
-export class TestClass extends ValueClass<1> {
+export class TestClass extends ValueClass {
   static make(v: ShapeOf<TestClass>): Make<TestClass> {
     return makeTestClass(v);
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -528,10 +528,10 @@
     lodash "^4.17.20"
     randexp "^0.5.3"
 
-"@smartlyio/oats@2.15.0":
-  version "2.15.0"
-  resolved "https://registry.yarnpkg.com/@smartlyio/oats/-/oats-2.15.0.tgz#84a48697f6ad13e36976e39c43b153b16472e210"
-  integrity sha512-vzylCmhUNBkD/3xn2ljhLZrH7FdgqeOl4mZQLWt1Pz/moM4zFKxg4s/uBnTaKP82HyQNEEOBIEWKfPMBVLO4uA==
+"@smartlyio/oats@2.15.1":
+  version "2.15.1"
+  resolved "https://registry.yarnpkg.com/@smartlyio/oats/-/oats-2.15.1.tgz#160d7c8ca041ce6778d9516b42debb3a246cb4ae"
+  integrity sha512-xfvoqRkjilOGNObp7VgZMfgH3/oS7R606QzQgNgQmVS0y4JU5PWAgmJ2HG5hKUwOAAcAkIY8hQqQApBFJGqXwQ==
   dependencies:
     "@smartlyio/safe-navigation" "^5.0.1"
     js-yaml "^4.0.0"


### PR DESCRIPTION
either `oats-runtime` or `oats` is going to be have to be merged with failing CI since this change breaks both 😅