### PR TITLE
Fix nested branded scalars are not unwrapped properly with ShapeOf

### DIFF
--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -13,7 +13,7 @@ type Scalar = number | string | boolean;
 const typeWitnessKey = Symbol();
 const tagKey = Symbol();
 
-type ScalarWithoutBrand<V> = V extends ShapedClass<infer S> ? S : V;
+type ScalarWithoutBrand<V> = V extends ShapedClass<infer S> ? ScalarWithoutBrand<S> : V;
 
 export type ShapeOf<A> = A extends Scalar
   ? ScalarWithoutBrand<A>


### PR DESCRIPTION
If you have a schema where you have multiple nested `$ref` scalars, eg. a `type: string` with an enum of values, the ShapeOf does not unwrap those properly.

For example consider that you have this:
```yaml
components:
  schemas:
    TestA:
      type: string
      enum:
        - a1
        - a2
    TestB:
      type: string
      enum:
        - b1
        - b2
    Test:
      oneOf:
        - $ref: '#/components/schemas/TestA'
        - $ref: '#/components/schemas/TestB'
```

Then somewhere eg. in your request body you do:
```
testField:
  $ref: '#/components/schemas/Test'
```

When trying to work with the `testField`, it doesn't unwrap the branded scalars properly, because they're in multiple levels. `ShapeOf<Test>` should give you `"a1" | "a2" | "b1" | "b2"`, but instead it gives you `("a1" & ShapedClass<"a1"> & BrandedClass<BrandOfTestA>) | ("a2" & ShapedClass<"a2"> & BrandedClass<BrandOfTestA>) | ("b1" & ShapedClass<"b1"> & BrandedClass<BrandOfTestB>) | ("b2" & ShapedClass<"b2"> & BrandedClass<BrandOfTestA>)`, which is obviously not what you want.

This change will fix the issue by properly unwrapping nested branded scalars.